### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,5 @@
-import { Buffer } from 'buffer'
-
 declare module '@consento/sync-randombytes' {
-  const cmd: <T extends Uint8Array | Buffer>(input: T) => T;
-  export default cmd
-}
+  import { Buffer } from 'buffer'
 
+  export default function <T extends Uint8Array | Buffer>(input: T): T;
+}


### PR DESCRIPTION
This was throwing `error TS2666: Exports and export assignments are not permitted in module augmentations.` for me. This takes advantage of single line default exports and moves the Buffer import within the declaration to avoid these issues.
@consento-org/maintainer
